### PR TITLE
fix(skills): add frontmatter to five skills (fixes #55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [6.58.2] - 2026-09-08
+
+### Skill frontmatter — five skills now carry name/description (fixes #55)
+
+#### Fixed
+- **`skills/autonomous-testing`, `skills/build-in-public`,
+  `skills/external-model-delegation`, `skills/model-routing`,
+  `skills/visual-validation`** — added YAML frontmatter (`name`, `description`,
+  `when-to-use`, `user-invocable`, `effort`) to each `SKILL.md`. They previously
+  started at an `#` heading with no frontmatter, so Claude Code had no `name` or
+  `description` to trigger them, and `skill_lint --fail-on error` (CI) was red.
+  `PYTHONPATH=scripts python -m skill_lint --fail-on error skills/` is now green
+  (0 errors).
+
+---
+
 ## [6.58.1] - 2026-08-21
 
 ### Retired Claude model IDs replaced in skill docs

--- a/skills/autonomous-testing/SKILL.md
+++ b/skills/autonomous-testing/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: autonomous-testing
+description: AI-driven testing agent that auto-discovers, generates, executes, evaluates, and fixes tests for any project type
+when-to-use: When setting up automated test generation or running an autonomous test-fix loop across Python, TypeScript, API, or web projects
+user-invocable: false
+effort: high
+---
+
 # Autonomous Testing Agent
 
 ## Overview

--- a/skills/build-in-public/SKILL.md
+++ b/skills/build-in-public/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: build-in-public
+description: Best practices for sharing engineering work publicly — what to post, what to withhold, and channel-specific guidance
+when-to-use: When drafting build-in-public posts, changelogs, or launch content for social channels
+user-invocable: false
+effort: low
+---
+
 # Build in Public — Best Practices
 
 ## Philosophy

--- a/skills/external-model-delegation/SKILL.md
+++ b/skills/external-model-delegation/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: external-model-delegation
+description: UserPromptSubmit hook pattern that classifies prompts into six cost tiers and delegates to external model CLIs
+when-to-use: When configuring or debugging prompt-based delegation to qwen3, deepseek, kimi, or codex
+user-invocable: false
+effort: medium
+---
+
 # External Model Delegation Pattern
 
 A `UserPromptSubmit` hook classifies every user prompt into one of six cost/performance tiers. The hook injects `additionalContext` instructing Claude to run a specific delegation script and return the output.

--- a/skills/model-routing/SKILL.md
+++ b/skills/model-routing/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: model-routing
+description: 9-tier model routing system with cascading classifier fallback and result auto-evaluation
+when-to-use: When configuring or debugging how prompts are classified and routed to the cheapest capable model
+user-invocable: false
+effort: medium
+---
+
 # Model Routing System
 
 ## How Routing Decisions Are Made

--- a/skills/visual-validation/SKILL.md
+++ b/skills/visual-validation/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: visual-validation
+description: Autonomous screenshot verification — captures, compares, and AI-evaluates UI changes for visual regressions
+when-to-use: When a UI or static-asset change needs visual verification before shipping
+user-invocable: false
+effort: medium
+---
+
 # Visual Validation — Autonomous Screenshot Verification
 
 ## Philosophy


### PR DESCRIPTION
Fixes #55.

## What
Adds YAML frontmatter to the five `SKILL.md` files that had none:
`autonomous-testing`, `build-in-public`, `external-model-delegation`, `model-routing`, `visual-validation`.

Each now carries `name` (matching its directory), `description`, `when-to-use`, `user-invocable`, and `effort`.

## Why
Without frontmatter, Claude Code has no `name`/`description` to decide the skill exists or when to trigger it, and `.github/workflows/skill-lint.yml` (`skill_lint --fail-on error`) was red on `main`.

## Verification
```
$ PYTHONPATH=scripts python -m skill_lint --fail-on error skills/
Errors: 0  Warnings: 95  Info: 74   # exit 0
```
The 95 warnings / 74 info are pre-existing and non-blocking (CI only fails on errors); tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JohuQy42xdpx1DKa3FCtQ