### PR TITLE
feat(shunt): configurable context shunt + size-aware read gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [6.59.0] - 2026-09-08
+
+### Context shunt — cheap reads, small context (+ a tightened read gate)
+
+#### Added
+- **`bin/bulk-read`** — hands large / multi-file reads to a cheap worker model
+  (default `deepseek --flash`, configurable via `SHUNT_MODEL`) and returns a
+  compact, cited summary; the raw files never enter Claude's context. Prints a
+  token-savings report to stderr. Inspired by Spotify's "shunt" plugin.
+- **`hooks/context-shunt-gate`** — configurable, **size-aware** PreToolUse hook
+  that supersedes the old size-blind `cbm-code-discovery-gate`. Steers reads of
+  large files (code *or* logs/generated output, via `Read` or a `cat`/`head`/
+  `tail` Bash call) to `bulk-read`, and keeps the once-per-session code-graph
+  nudge. Fail-open (a bug can never wedge the session).
+- **`skills/context-shunt/SKILL.md`** — when to read raw vs shunt vs graph.
+- **`templates/shunt.conf`** — config seeded to `~/.claude/shunt.conf`:
+  `SHUNT` (on/off), `SHUNT_MIN_LINES` (default 350), `SHUNT_MODE`
+  (`suggest`/`block`/`off`, default `suggest` — nudges, never blocks),
+  `SHUNT_GRAPH_NUDGE`, `SHUNT_MODEL`.
+
+#### Changed
+- `templates/settings.json` registers `context-shunt-gate` on `Read|Grep|Glob|Search`
+  and `Bash`, so `/initialize-project` projects get it. `install.sh` ships the
+  hook, `bulk-read`, and the config (non-destructively).
+
+This is deliberately orthogonal to srooter / `route-task` (which route whole
+turns): the shunt only trims what a single tool call pulls in when the turn is
+already on the main model — the one slice whole-turn routing can't reach.
+
+#### Tests
+- `tests/test_context_shunt.py` — 15 cases: fail-open on bad input, block/suggest/off
+  modes, small-read passthrough, Bash `cat` gating, non-read commands ignored, the
+  graph nudge, and `bulk-read` guards + corpus piping.
+
+---
+
 ## [6.58.2] - 2026-09-08
 
 ### Skill frontmatter — five skills now carry name/description (fixes #55)

--- a/README.md
+++ b/README.md
@@ -169,6 +169,24 @@ claude        # now routed through srooter
 
 Pick the model you "follow" once with `/model-config` — Maggy, the route-task hooks, and srooter all honor the same choice. Trivial asks stay on the cheap/local tier; real coding goes to your primary model (e.g. MiniMax-M2.5).
 
+### Context shunt — cheap reads, small context
+
+Gateway routing picks the model for a *turn*. The **context shunt** trims what a
+single *tool call* pulls in when the turn is legitimately on your main model: a
+PreToolUse hook (`context-shunt-gate`) catches reads of large files — code *or*
+logs/generated output — and steers them to `bulk-read`, which hands the files to
+a cheap worker (default `deepseek --flash`) and returns a compact summary. The
+raw bytes never enter context. For code symbols it points at the graph
+(`get_code_snippet`) instead. Inspired by Spotify's "shunt" plugin.
+
+Fully configurable in `~/.claude/shunt.conf` (or env): `SHUNT=on|off`,
+`SHUNT_MIN_LINES` (default 350), `SHUNT_MODE=suggest|block|off` (default
+`suggest` — nudges, never blocks), `SHUNT_MODEL`. See the `context-shunt` skill.
+
+```bash
+bulk-read "how does token refresh work?" src/auth/session.ts src/auth/refresh.ts
+```
+
 ---
 
 ## Parallel Development (Polyphony)

--- a/bin/bulk-read
+++ b/bin/bulk-read
@@ -1,0 +1,92 @@
+#!/bin/bash
+# bulk-read — offload large / multi-file reads to a cheap worker model.
+#
+# The files are handed to a cheap model that answers a question about them and
+# returns a compact summary. The raw files never enter Claude's context, which
+# is where the token savings come from (the "context shunt" pattern).
+#
+# Usage:
+#   bulk-read "question about the files" file1 [file2 ...]
+#   cat manifest.txt | xargs bulk-read "what does the auth flow do?"
+#
+# Config (environment, or KEY=VALUE lines in ~/.claude/shunt.conf):
+#   SHUNT_MODEL   worker command (default: "deepseek --flash")
+#   SHUNT_WORKER  alias for SHUNT_MODEL (SHUNT_MODEL wins if both set)
+#
+# Contract: this is a plain CLI. It always runs when invoked directly — the
+# SHUNT on/off switch only governs the PreToolUse hook, never an explicit call.
+
+set -o pipefail
+
+CONF="${SHUNT_CONF:-$HOME/.claude/shunt.conf}"
+[ -f "$CONF" ] && . "$CONF" 2>/dev/null
+
+WORKER="${SHUNT_MODEL:-${SHUNT_WORKER:-deepseek --flash}}"
+
+usage() {
+  echo "Usage: bulk-read \"<question>\" <file> [file ...]" >&2
+  exit 2
+}
+
+QUESTION="$1"
+[ -z "$QUESTION" ] && usage
+shift
+[ "$#" -eq 0 ] && usage
+
+# Verify the worker binary exists before building a big prompt.
+WORKER_BIN="${WORKER%% *}"
+if ! command -v "$WORKER_BIN" >/dev/null 2>&1; then
+  echo "bulk-read: worker '$WORKER_BIN' not found on PATH (set SHUNT_MODEL)" >&2
+  exit 3
+fi
+
+# Build the corpus: each file wrapped in an XML boundary so the worker can cite
+# paths cleanly and never confuse one file's content for another's.
+CORPUS=""
+RAW_BYTES=0
+FILE_COUNT=0
+for f in "$@"; do
+  if [ ! -f "$f" ]; then
+    echo "bulk-read: skipping missing file: $f" >&2
+    continue
+  fi
+  body="$(cat "$f" 2>/dev/null)" || continue
+  CORPUS="${CORPUS}"$'\n'"<file path=\"$f\">"$'\n'"${body}"$'\n'"</file>"$'\n'
+  RAW_BYTES=$((RAW_BYTES + ${#body}))
+  FILE_COUNT=$((FILE_COUNT + 1))
+done
+
+if [ "$FILE_COUNT" -eq 0 ]; then
+  echo "bulk-read: no readable files given" >&2
+  exit 3
+fi
+
+PROMPT="You are a code/context reader. Answer the QUESTION using ONLY the files
+below. Output tight, structured bullets — no preamble, no prose, no restating
+the question. Cite evidence as path:line. If the answer is not in the files, say
+'NOT FOUND IN PROVIDED FILES' and nothing else.
+
+QUESTION:
+${QUESTION}
+
+FILES:
+${CORPUS}"
+
+OUT="$(printf '%s' "$PROMPT" | $WORKER 2>/dev/null)"
+STATUS=$?
+if [ "$STATUS" -ne 0 ] || [ -z "$OUT" ]; then
+  echo "bulk-read: worker '$WORKER' returned no output (exit $STATUS)" >&2
+  exit 4
+fi
+
+printf '%s\n' "$OUT"
+
+# Token report (approx: ~4 chars/token) on stderr so it never pollutes the answer.
+SUM_BYTES=${#OUT}
+RAW_TOK=$((RAW_BYTES / 4))
+SUM_TOK=$((SUM_BYTES / 4))
+if [ "$RAW_TOK" -gt 0 ]; then
+  SAVED=$(( (RAW_TOK - SUM_TOK) * 100 / RAW_TOK ))
+  echo "[bulk-read] $FILE_COUNT file(s) via '$WORKER': ~${RAW_TOK} tok raw -> ~${SUM_TOK} tok summary (~${SAVED}% saved)" >&2
+fi
+exit 0

--- a/hooks/context-shunt-gate
+++ b/hooks/context-shunt-gate
@@ -1,0 +1,94 @@
+#!/bin/bash
+# context-shunt-gate — PreToolUse hook. Keeps large reads out of Claude's
+# context and nudges code discovery toward the code graph.
+#
+# Supersedes the older cbm-code-discovery-gate: it keeps the once-per-session
+# graph nudge AND adds size-aware handling that also covers large *non-code*
+# reads (logs, generated files, long markdown) — the case whole-prompt routing
+# (srooter/route-task) can't reach because the turn is already on Claude.
+#
+# Two independent, configurable behaviours:
+#   A. Graph nudge  — first Grep/Glob/Read/Search per session -> point at
+#                     codebase-memory-mcp (deterministic, free, no fidelity loss).
+#   B. Large read   — a Read (or a `cat`/`head`/`tail`/`less` Bash call) on a
+#                     file over SHUNT_MIN_LINES -> steer to `bulk-read` so the
+#                     file is summarised by a cheap worker instead of dumped
+#                     into context.
+#
+# Config (environment, or KEY=VALUE lines in ~/.claude/shunt.conf):
+#   SHUNT              on|off        master switch          (default on)
+#   SHUNT_MIN_LINES    integer       large-read threshold   (default 350)
+#   SHUNT_MODE         suggest|block|off  large-read action (default suggest)
+#   SHUNT_GRAPH_NUDGE  on|off        once-per-session nudge (default on)
+#
+# Contract: FAIL-OPEN. Any parse/error path exits 0 with no output so a bug here
+# can never block the session. "block" is a deliberate, configured decision
+# (exit 2, message on stderr); "suggest" emits valid PreToolUse JSON and allows.
+# No `set -euo pipefail`.
+
+INPUT=$(cat 2>/dev/null || true)
+
+CONF="${SHUNT_CONF:-$HOME/.claude/shunt.conf}"
+[ -f "$CONF" ] && . "$CONF" 2>/dev/null
+
+SHUNT="${SHUNT:-on}"
+[ "$SHUNT" = "off" ] && exit 0
+
+MIN_LINES="${SHUNT_MIN_LINES:-350}"
+MODE="${SHUNT_MODE:-suggest}"
+GRAPH_NUDGE="${SHUNT_GRAPH_NUDGE:-on}"
+case "$MIN_LINES" in ''|*[!0-9]*) MIN_LINES=350 ;; esac
+
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || echo "")
+[ -z "$TOOL_NAME" ] && exit 0
+
+# --- Resolve a candidate file path (Read tool, or a simple read-only Bash cmd)
+FILE_PATH=""
+case "$TOOL_NAME" in
+  Read)
+    FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null || echo "")
+    ;;
+  Bash)
+    CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
+    # Only treat plain read commands as read targets; ignore pipelines that do work.
+    if echo "$CMD" | grep -qE '^\s*(cat|head|tail|less|more)\s+'; then
+      FILE_PATH=$(echo "$CMD" | grep -oE '(cat|head|tail|less|more)\s+[^ |;&<>]+' | head -1 | awk '{print $2}')
+      FILE_PATH="${FILE_PATH/#\~/$HOME}"
+    fi
+    ;;
+esac
+
+# --- B. Large-read shunt (only when we have a real, oversized file)
+if [ -n "$FILE_PATH" ] && [ -f "$FILE_PATH" ] && [ "$MODE" != "off" ]; then
+  LINES=$(wc -l < "$FILE_PATH" 2>/dev/null | tr -d ' ')
+  case "$LINES" in ''|*[!0-9]*) LINES=0 ;; esac
+  if [ "$LINES" -gt "$MIN_LINES" ]; then
+    MSG="Large file ($LINES lines > $MIN_LINES). Don't read it raw into context. For a QUESTION about it, run: bulk-read \"<question>\" \"$FILE_PATH\" (cheap worker summarises it). For a code symbol, prefer get_code_snippet(qualified_name). Read raw only if you must edit this exact file."
+    if [ "$MODE" = "block" ]; then
+      echo "$MSG" >&2
+      exit 2
+    fi
+    # suggest: allow, but surface the nudge
+    MSG="$MSG" jq -n --arg r "$MSG" \
+      '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"allow",permissionDecisionReason:$r}}' \
+      2>/dev/null || true
+    exit 0
+  fi
+fi
+
+# --- A. Once-per-session code-discovery graph nudge
+if [ "$GRAPH_NUDGE" = "on" ]; then
+  case "$TOOL_NAME" in
+    Grep|Glob|Read|Search)
+      GATE="/tmp/cbm-code-discovery-gate-$PPID"
+      find /tmp -name 'cbm-code-discovery-gate-*' -mtime +1 -delete 2>/dev/null
+      if [ ! -f "$GATE" ]; then
+        touch "$GATE" 2>/dev/null
+        echo 'For code discovery, use codebase-memory-mcp first: search_graph(name_pattern) for functions/classes, trace_path() for call chains, get_code_snippet(qualified_name) to read source. If not indexed, run index_repository. Fall back to Grep/Glob/Read for text content only. If you need Grep, retry.' >&2
+        exit 2
+      fi
+      ;;
+  esac
+fi
+
+exit 0

--- a/install.sh
+++ b/install.sh
@@ -93,6 +93,11 @@ cp "$SCRIPT_DIR/templates/"* "$CLAUDE_DIR/templates/" 2>/dev/null || true
 chmod +x "$CLAUDE_DIR/templates/"*.sh 2>/dev/null || true
 echo "✓ Installed templates (CLAUDE.md, AGENTS.md, CLAUDE.local.md, settings.json, config.toml, and all hook scripts)"
 
+# Seed the active context-shunt config (non-destructive — never clobber edits).
+# The context-shunt-gate hook + bulk-read script read ~/.claude/shunt.conf.
+cp -n "$SCRIPT_DIR/templates/shunt.conf" "$CLAUDE_DIR/shunt.conf" 2>/dev/null || true
+echo "✓ Context-shunt ready (hook: context-shunt-gate, worker: bulk-read, config: ~/.claude/shunt.conf)"
+
 # Cross-tool config installation
 if echo "$DETECTED_AGENTS" | grep -q "kimi"; then
     mkdir -p "$HOME/.kimi"

--- a/skills/context-shunt/SKILL.md
+++ b/skills/context-shunt/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: context-shunt
+description: Offload large / multi-file reads to a cheap worker model so raw files never enter Claude's context (token savings)
+when-to-use: When answering a question that requires reading large or many files, reviewing logs, or scanning generated output — anything you don't need to edit
+user-invocable: false
+effort: low
+---
+
+# Context Shunt — Read Cheap, Keep Context Small
+
+Reading big files into context is the most expensive thing an agent does for the
+least reasoning value. The shunt hands those reads to a cheap worker model
+(`bulk-read`) that answers a question about the files and returns a compact
+summary. The raw bytes never enter this session's context.
+
+This is orthogonal to whole-turn routing (srooter / `route-task`): those pick the
+model for the *turn*; the shunt trims what a *tool call* pulls into context when
+the turn is legitimately here.
+
+## Decision: read raw, shunt, or graph?
+
+- **Editing this exact file** — read it raw. You need every line; never edit against a summary.
+- **A fact/answer across large or many files** — `bulk-read "<question>" file...`.
+- **A code symbol (function/class/route)** — `get_code_snippet(qualified_name)`: free and exact.
+- **Small file (under threshold) you need in full** — read it raw.
+
+A shunt answer is for understanding, not for producing a diff.
+
+## Usage
+
+```bash
+bulk-read "how does token refresh work?" src/auth/session.ts src/auth/refresh.ts
+bulk-read "which config keys are read at startup?" $(git ls-files 'config/*.yaml')
+```
+
+`bulk-read` prints structured bullets citing `path:line`, or
+`NOT FOUND IN PROVIDED FILES`. A token-savings report goes to stderr.
+
+## Configuration
+
+Env vars or `~/.claude/shunt.conf` (see `templates/shunt.conf`):
+
+- `SHUNT` — `on`/`off` master switch for the PreToolUse hook.
+- `SHUNT_MIN_LINES` — large-read threshold (default 350).
+- `SHUNT_MODE` — `suggest` (default) / `block` / `off` for the hook's large-read action.
+- `SHUNT_GRAPH_NUDGE` — `on`/`off` once-per-session graph nudge.
+- `SHUNT_MODEL` — worker command (default `deepseek --flash`; also `gemini-api --flash-lite`, `qwen3`, `glm`).
+
+The `context-shunt-gate` PreToolUse hook enforces the thresholds; this skill tells
+you when to reach for `bulk-read` yourself.

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -60,6 +60,28 @@
     ],
     "PreToolUse": [
       {
+        "matcher": "Read|Grep|Glob|Search",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if [ -x \"$HOME/.claude/hooks/context-shunt-gate\" ]; then exec \"$HOME/.claude/hooks/context-shunt-gate\"; fi; exit 0",
+            "timeout": 3,
+            "statusMessage": "Checking read size / code-graph nudge..."
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if [ -x \"$HOME/.claude/hooks/context-shunt-gate\" ]; then exec \"$HOME/.claude/hooks/context-shunt-gate\"; fi; exit 0",
+            "timeout": 3,
+            "statusMessage": "Checking read size..."
+          }
+        ]
+      },
+      {
         "hooks": [
           {
             "type": "command",

--- a/templates/shunt.conf
+++ b/templates/shunt.conf
@@ -1,0 +1,25 @@
+# context-shunt configuration — sourced by hooks/context-shunt-gate and bin/bulk-read.
+# Copy to ~/.claude/shunt.conf and edit. Every value can also be set as an
+# environment variable (env wins over this file). Lines are plain KEY=VALUE.
+
+# Master switch for the PreToolUse hook. off = hook does nothing (bulk-read still
+# works when you call it directly). srooter/route-task already route whole turns;
+# set this off if you don't want per-read nudging on top of that.
+SHUNT=on
+
+# Large-read threshold, in lines. Reads over this are steered to bulk-read.
+# Spotify's shunt used 350; raise it if you get nudged too often.
+SHUNT_MIN_LINES=350
+
+# What to do on a large read:
+#   suggest = allow the read but surface a nudge     (default, no surprises)
+#   block   = deny the raw read, force bulk-read/graph
+#   off     = ignore file size entirely
+SHUNT_MODE=suggest
+
+# Once-per-session nudge toward the code graph on the first Grep/Glob/Read/Search.
+SHUNT_GRAPH_NUDGE=on
+
+# Worker model bulk-read hands files to. Any ~/bin wrapper that reads a prompt on
+# stdin: "deepseek --flash" (default), "gemini-api --flash-lite", "qwen3", "glm".
+SHUNT_MODEL=deepseek --flash

--- a/tests/test_context_shunt.py
+++ b/tests/test_context_shunt.py
@@ -1,0 +1,150 @@
+"""Behavioural tests for the context-shunt gate hook and bulk-read worker.
+
+The gate is a PreToolUse hook that (a) steers large reads to `bulk-read` and
+(b) nudges code discovery toward the code graph. Unlike the injection hooks it
+MAY block (exit 2) — but only as a *configured* decision. On any malformed or
+empty input it must fail-open (exit 0) so a bug can never wedge the session.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+GATE = ROOT / "hooks" / "context-shunt-gate"
+BULK = ROOT / "bin" / "bulk-read"
+
+
+def _run(argv, stdin="", env=None):
+    base = {"PATH": "/usr/bin:/bin:/usr/local/bin", "HOME": "/tmp/shunt-nohome"}
+    if env:
+        base.update(env)
+    return subprocess.run(
+        argv, input=stdin, capture_output=True, text=True, timeout=20, env=base
+    )
+
+
+def _gate(stdin, env=None):
+    return _run(["bash", str(GATE)], stdin=stdin, env=env)
+
+
+def _big(tmp_path, lines=400):
+    f = tmp_path / "big.txt"
+    f.write_text("\n".join(str(i) for i in range(lines)) + "\n")
+    return f
+
+
+# --- fail-open contract -----------------------------------------------------
+
+@pytest.mark.parametrize("stdin", ["", "{not json", '{"tool_name":null}', "null"])
+def test_gate_fails_open_on_bad_input(stdin):
+    r = _gate(stdin, env={"SHUNT_GRAPH_NUDGE": "off"})
+    assert r.returncode == 0
+    assert r.stdout.strip() == ""
+
+
+def test_master_switch_off_disables_everything(tmp_path):
+    f = _big(tmp_path)
+    payload = json.dumps({"tool_name": "Read", "tool_input": {"file_path": str(f)}})
+    r = _gate(payload, env={"SHUNT": "off"})
+    assert r.returncode == 0
+    assert r.stdout.strip() == ""
+
+
+# --- large-read shunt -------------------------------------------------------
+
+def test_large_read_block_mode_denies_with_bulk_read_hint(tmp_path):
+    f = _big(tmp_path)
+    payload = json.dumps({"tool_name": "Read", "tool_input": {"file_path": str(f)}})
+    r = _gate(payload, env={"SHUNT_MODE": "block", "SHUNT_GRAPH_NUDGE": "off"})
+    assert r.returncode == 2
+    assert "bulk-read" in r.stderr
+
+
+def test_large_read_suggest_mode_allows_with_valid_json(tmp_path):
+    f = _big(tmp_path)
+    payload = json.dumps({"tool_name": "Read", "tool_input": {"file_path": str(f)}})
+    r = _gate(payload, env={"SHUNT_MODE": "suggest", "SHUNT_GRAPH_NUDGE": "off"})
+    assert r.returncode == 0
+    out = json.loads(r.stdout)  # must be valid JSON
+    hso = out["hookSpecificOutput"]
+    assert hso["hookEventName"] == "PreToolUse"
+    assert hso["permissionDecision"] == "allow"
+    assert "bulk-read" in hso["permissionDecisionReason"]
+
+
+def test_small_read_does_not_fire(tmp_path):
+    f = tmp_path / "small.txt"
+    f.write_text("a\nb\nc\n")
+    payload = json.dumps({"tool_name": "Read", "tool_input": {"file_path": str(f)}})
+    r = _gate(payload, env={"SHUNT_MODE": "block", "SHUNT_GRAPH_NUDGE": "off"})
+    assert r.returncode == 0
+    assert r.stdout.strip() == ""
+
+
+def test_bash_cat_large_file_is_gated(tmp_path):
+    f = _big(tmp_path)
+    payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": f"cat {f}"}})
+    r = _gate(payload, env={"SHUNT_MODE": "block", "SHUNT_GRAPH_NUDGE": "off"})
+    assert r.returncode == 2
+
+
+def test_bash_non_read_command_is_ignored(tmp_path):
+    f = _big(tmp_path)
+    payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": f"rm -f {f}"}})
+    r = _gate(payload, env={"SHUNT_MODE": "block", "SHUNT_GRAPH_NUDGE": "off"})
+    assert r.returncode == 0
+    assert r.stdout.strip() == ""
+
+
+def test_mode_off_ignores_file_size(tmp_path):
+    f = _big(tmp_path)
+    payload = json.dumps({"tool_name": "Read", "tool_input": {"file_path": str(f)}})
+    r = _gate(payload, env={"SHUNT_MODE": "off", "SHUNT_GRAPH_NUDGE": "off"})
+    assert r.returncode == 0
+    assert r.stdout.strip() == ""
+
+
+# --- code-discovery graph nudge ---------------------------------------------
+
+def test_graph_nudge_blocks_first_discovery_call():
+    # Clear any session marker so this call is treated as the first.
+    for p in Path("/tmp").glob("cbm-code-discovery-gate-*"):
+        try:
+            p.unlink()
+        except OSError:
+            pass
+    payload = json.dumps({"tool_name": "Grep", "tool_input": {"pattern": "x"}})
+    r = _gate(payload, env={"SHUNT_GRAPH_NUDGE": "on", "SHUNT_MODE": "off"})
+    assert r.returncode == 2
+    assert "codebase-memory-mcp" in r.stderr
+
+
+# --- bulk-read worker -------------------------------------------------------
+
+def test_bulk_read_usage_without_args():
+    r = _run(["bash", str(BULK)])
+    assert r.returncode == 2
+    assert "Usage" in r.stderr
+
+
+def test_bulk_read_missing_worker_binary(tmp_path):
+    f = tmp_path / "f.txt"
+    f.write_text("hello\n")
+    r = _run(["bash", str(BULK), "q?", str(f)], env={"SHUNT_MODEL": "no-such-bin-xyz"})
+    assert r.returncode == 3
+    assert "not found" in r.stderr
+
+
+def test_bulk_read_pipes_corpus_to_worker(tmp_path):
+    f = tmp_path / "f.txt"
+    f.write_text("needle-value\n")
+    # `cat` as a stand-in worker echoes the prompt (which embeds the file body).
+    r = _run(["bash", str(BULK), "what value?", str(f)], env={"SHUNT_MODEL": "cat"})
+    assert r.returncode == 0
+    assert "needle-value" in r.stdout
+    assert "% saved" in r.stderr


### PR DESCRIPTION
## What
Adds a **context shunt**: large / multi-file reads get handed to a cheap worker model that returns a compact summary, so the raw files never enter Claude's context. Also **tightens the read gate** (the old `cbm-code-discovery-gate` was size-blind and only nagged once per session).

Inspired by [Spotify's "shunt" plugin](https://engineering.atspotify.com/2026/9/portal-by-spotify-cut-my-claude-code-token-usage-by-90).

## Why it's not redundant with srooter
srooter / `route-task` route a whole **turn** to a model. The shunt trims what a single **tool call** pulls in when the turn is legitimately on the main model — a big read for one fact. That's the one slice whole-turn routing can't reach. It's off-switchable (`SHUNT=off`) for anyone who'd rather rely on gateway routing alone.

## Pieces
- **`bin/bulk-read`** — files → cheap worker (default `deepseek --flash`) → cited summary + token-savings report on stderr.
- **`hooks/context-shunt-gate`** — configurable, size-aware PreToolUse hook. Supersedes `cbm-code-discovery-gate`; covers large **non-code** reads too (logs, generated output, via `Read` or `cat`/`head`/`tail`). Keeps the once-per-session graph nudge. **Fail-open.**
- **`skills/context-shunt/SKILL.md`** — read raw (edit target) vs shunt (Q&A) vs graph (code symbol). Lints clean.
- **`templates/shunt.conf`** — `SHUNT`, `SHUNT_MIN_LINES` (350), `SHUNT_MODE` (`suggest` default — nudges, never blocks / `block` / `off`), `SHUNT_GRAPH_NUDGE`, `SHUNT_MODEL`. Seeded by `install.sh`.
- **`templates/settings.json`** — registers the gate on `Read|Grep|Glob|Search` + `Bash` for `/initialize-project`.

## Config choices (per request)
Default worker `deepseek --flash`; default gate mode **suggest** (non-blocking). Both overridable.

## Verification
```
$ python -m pytest tests/test_context_shunt.py tests/test_hook_robustness.py -q
34 passed
$ PYTHONPATH=scripts python -m skill_lint --fail-on error skills/    # exit 0
```
15 new cases: fail-open on bad input, block/suggest/off modes, small-read passthrough, Bash `cat` gating, non-read commands ignored, graph nudge, `bulk-read` guards + corpus piping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JohuQy42xdpx1DKa3FCtQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Context Shunt support for large or multi-file reads, producing compact summaries with source-line citations.
  - Added configurable worker-model support, read-size thresholds, suggestion or blocking modes, and optional code-graph guidance.
  - Added automatic setup for the Context Shunt configuration during installation.

- **Documentation**
  - Added usage guidance, configuration details, examples, and decision recommendations for working with large codebases.

- **Tests**
  - Added coverage for read handling, configuration modes, command validation, error cases, and summary generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->